### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/uuid.js
+++ b/lib/uuid.js
@@ -1,4 +1,4 @@
-var uuidPackage = require('node-uuid');
+var uuidPackage = require('uuid');
 
 module.exports = function uuid(prefix) {
 	return (prefix ? (prefix + '-') : '') + uuidPackage.v4();

--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
     "express-winston": "^0.3.1",
     "hiredis": "^0.4.0",
     "ndjson": "^1.4.1",
-    "node-uuid": "^1.4.3",
     "redis": "^0.12.1",
     "request": "^2.59.0",
+    "uuid": "^3.0.0",
     "winston": "^1.0.1",
     "winston-context": "0.0.7"
   },

--- a/test/lib/listener.js
+++ b/test/lib/listener.js
@@ -3,7 +3,7 @@ var express = require('express');
 var assert = require('assert');
 var bodyParser = require('body-parser');
 var path = require('path');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var extend = require('extend');
 var nextPort = require('../nextPort');
 


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.